### PR TITLE
chore: loosen license restrictions to allow osi approved open source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable -->
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Loosen license restrictions to allow any OSI approved open source derivations
+
 ## [3.0.0] - 2023-01-02
 
 ### Added

--- a/LICENSE
+++ b/LICENSE
@@ -337,3 +337,12 @@ proprietary programs.  If your program is a subroutine library, you may
 consider it more useful to permit linking proprietary applications with the
 library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.
+
+
+          GPL LICENSE EXCEPTION FOR DERIVED OPEN SOURCE SOFTWARE
+
+The GPL version 2 license applies only to the Nix CI infrastructure provided
+by this template repository, including any modifications made to the infrastructure.
+Any software that uses or is derived from this template may be licensed under any
+OSI approved open source license, without being subject to the GPL version 2 license
+of the infrastructure.

--- a/README.md
+++ b/README.md
@@ -17,3 +17,14 @@ to start a repo based on this template. **Do _not_ fork it.**
 
 All contributions are welcome!
 See [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+## License
+
+This template is [licensed according to GPL version 2](./LICENSE),
+with the following exception:
+
+The license applies only to the Nix CI infrastructure provided by this template
+repository, including any modifications made to the infrastructure.
+Any software that uses or is derived from this template may be licensed under any
+[OSI approved open source license](https://opensource.org/licenses/),
+without being subject to the GPL version 2 license of this template.

--- a/flake.nix
+++ b/flake.nix
@@ -48,11 +48,6 @@
           editorconfig-checker.enable = true;
           markdownlint.enable = true;
         };
-        settings = {
-          markdownlint.config = {
-            MD024 = false; # Duplicate heading
-          };
-        };
       };
 
       devShell = pkgs.mkShell {


### PR DESCRIPTION
@MangoIV as discussed, here is my proposal to loosen the license restrictions.
I'll make this dependent on your approval, since [you have contributed much of the nix flake infrastructure to haskell-tools.nvim](https://github.com/mrcjkb/haskell-tools.nvim/pull/59), from which this template is derived.

I'm also open to suggestions.

If this is approved, I will also apply this change to my [nvim-lua-nix-plugin-template](https://github.com/MrcJkb/nvim-lua-nix-plugin-template) for Neovim plugins.